### PR TITLE
Restore presubmit run multiple scripts functionality (#1811) (#1830)

### DIFF
--- a/config/prow-staging/core/config.yaml
+++ b/config/prow-staging/core/config.yaml
@@ -60,6 +60,8 @@ deck:
           - 'panic: test timed out after.*$'
           # test case failure
           - 'FAIL:'
+          # step failed
+          - 'Step failed:'
           # boskos error
           - 'boskos failed to acquire project'
           # cluster creation error

--- a/config/prow/core/config.yaml
+++ b/config/prow/core/config.yaml
@@ -60,6 +60,8 @@ deck:
           - 'panic: test timed out after.*$'
           # test case failure
           - 'FAIL:'
+          # step failed
+          - 'Step failed:'
           # boskos error
           - 'boskos failed to acquire project'
           # cluster creation error

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -70,10 +70,11 @@ integration tests).
 Use the flags `--build-tests`, `--unit-tests` and `--integration-tests` to run a
 specific set of tests.
 
-To run a specific program as a test, use the `--run-test` flag, and provide the
+To run specific programs as a test, use the `--run-test` flag, and provide the
 program as the argument. If arguments are required for the program, pass
 everything as a single quotes argument. For example,
-`./presubmit-tests.sh --run-test "test/my/test data"`.
+`./presubmit-tests.sh --run-test "test/my/test data"`. This flag can be used
+repeatedly, and each one will be ran in sequential order.
 
 The script will automatically skip all presubmit tests for PRs where all changed
 files are exempt of tests (e.g., a PR changing only the `OWNERS` file).

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -327,6 +327,13 @@ function capture_output() {
   return ${failed}
 }
 
+# Print failed step, which could be highlighted by spyglass.
+# Parameters: $1...n - description of step that failed
+function step_failed() {
+  local spyglass_token="Step failed:"
+  echo "${spyglass_token} $@"
+}
+
 # Create a temporary file with the given extension in a way that works on both Linux and macOS.
 # Parameters: $1 - file name without extension (e.g. 'myfile_XXXX')
 #             $2 - file extension (e.g. 'xml')

--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -93,19 +93,19 @@ function run_build_tests() {
   local failed=0
   # Run pre-build tests, if any
   if function_exists pre_build_tests; then
-    pre_build_tests || failed=1
+    pre_build_tests || { failed=1; step_failed "pre_build_tests"; }
   fi
   # Don't run build tests if pre-build tests failed
   if (( ! failed )); then
     if function_exists build_tests; then
-      build_tests || failed=1
+      build_tests || { failed=1; step_failed "build_tests"; }
     else
-      default_build_test_runner || failed=1
+      default_build_test_runner || { failed=1; step_failed "default_build_test_runner"; }
     fi
   fi
   # Don't run post-build tests if pre/build tests failed
   if (( ! failed )) && function_exists post_build_tests; then
-    post_build_tests || failed=1
+    post_build_tests || { failed=1; step_failed "post_build_tests"; }
   fi
   results_banner "Build" ${failed}
   return ${failed}
@@ -213,19 +213,19 @@ function run_unit_tests() {
   local failed=0
   # Run pre-unit tests, if any
   if function_exists pre_unit_tests; then
-    pre_unit_tests || failed=1
+    pre_unit_tests || { failed=1; step_failed "pre_unit_tests"; }
   fi
   # Don't run unit tests if pre-unit tests failed
   if (( ! failed )); then
     if function_exists unit_tests; then
-      unit_tests || failed=1
+      unit_tests || { failed=1; step_failed "unit_tests"; }
     else
-      default_unit_test_runner || failed=1
+      default_unit_test_runner || { failed=1; step_failed "default_unit_test_runner"; }
     fi
   fi
   # Don't run post-unit tests if pre/unit tests failed
   if (( ! failed )) && function_exists post_unit_tests; then
-    post_unit_tests || failed=1
+    post_unit_tests || { failed=1; step_failed "post_unit_tests"; }
   fi
   results_banner "Unit" ${failed}
   return ${failed}
@@ -249,19 +249,19 @@ function run_integration_tests() {
   local failed=0
   # Run pre-integration tests, if any
   if function_exists pre_integration_tests; then
-    pre_integration_tests || failed=1
+    pre_integration_tests || { failed=1; step_failed "pre_integration_tests"; }
   fi
   # Don't run integration tests if pre-integration tests failed
   if (( ! failed )); then
     if function_exists integration_tests; then
-      integration_tests || failed=1
+      integration_tests || { failed=1; step_failed "integration_tests"; }
     else
-      default_integration_test_runner || failed=1
+      default_integration_test_runner || { failed=1; step_failed "default_integration_test_runner"; }
     fi
   fi
   # Don't run integration tests if pre/integration tests failed
   if (( ! failed )) && function_exists post_integration_tests; then
-    post_integration_tests || failed=1
+    post_integration_tests || { failed=1; step_failed "post_integration_tests"; }
   fi
   results_banner "Integration" ${failed}
   return ${failed}
@@ -275,6 +275,7 @@ function default_integration_test_runner() {
     echo "Running integration test ${e2e_test}"
     if ! ${e2e_test} ${options}; then
       failed=1
+      step_failed "${e2e_test} ${options}"
     fi
   done
   return ${failed}
@@ -327,7 +328,7 @@ function main() {
 
   [[ -z $1 ]] && set -- "--all-tests"
 
-  local TEST_TO_RUN=""
+  local TESTS_TO_RUN=()
 
   while [[ $# -ne 0 ]]; do
     local parameter=$1
@@ -343,7 +344,7 @@ function main() {
       --run-test)
         shift
         [[ $# -ge 1 ]] || abort "missing executable after --run-test"
-        TEST_TO_RUN="$1"
+        TESTS_TO_RUN+=("$1")
         ;;
       *) abort "error: unknown option ${parameter}" ;;
     esac
@@ -353,7 +354,7 @@ function main() {
   readonly RUN_BUILD_TESTS
   readonly RUN_UNIT_TESTS
   readonly RUN_INTEGRATION_TESTS
-  readonly TEST_TO_RUN
+  readonly TESTS_TO_RUN
 
   cd ${REPO_ROOT_DIR}
 
@@ -361,7 +362,7 @@ function main() {
 
   local failed=0
 
-  if [[ -n "${TEST_TO_RUN}" ]]; then
+  if [[ ${#TESTS_TO_RUN[@]} > 0 ]]; then
     if (( RUN_BUILD_TESTS || RUN_UNIT_TESTS || RUN_INTEGRATION_TESTS )); then
       abort "--run-test must be used alone"
     fi
@@ -370,17 +371,19 @@ function main() {
       header "Documentation only PR, skipping running custom test"
       exit 0
     fi
-    ${TEST_TO_RUN} || failed=1
+    for test_to_run in "${TESTS_TO_RUN[@]}"; do
+      ${test_to_run} || { failed=1; step_failed "${test_to_run}"; }
+    done
   fi
 
-  run_build_tests || failed=1
+  run_build_tests || { failed=1; step_failed "run_build_tests"; }
   # If PRESUBMIT_TEST_FAIL_FAST is set to true, don't run unit tests if build tests failed
   if (( ! PRESUBMIT_TEST_FAIL_FAST )) || (( ! failed )); then
-    run_unit_tests || failed=1
+    run_unit_tests || { failed=1; step_failed "run_unit_tests"; }
   fi
   # If PRESUBMIT_TEST_FAIL_FAST is set to true, don't run integration tests if build/unit tests failed
   if (( ! PRESUBMIT_TEST_FAIL_FAST )) || (( ! failed )); then
-    run_integration_tests || failed=1
+    run_integration_tests || { failed=1; step_failed "run_integration_tests"; }
   fi
 
   exit ${failed}

--- a/test/unit/presubmit-tests.sh
+++ b/test/unit/presubmit-tests.sh
@@ -270,4 +270,10 @@ test_function ${SUCCESS} "BUILD TESTS PASSED" main --build-tests
 test_function ${SUCCESS} "EXECUTING default_build_test_runner" main --build-tests
 test_function ${SUCCESS} "BUILD TESTS PASSED" call_function_pre run_markdown_build_tests
 
+echo ">> Testing custom and multi-script execution"
+
+test_function ${SUCCESS} "Completed" main --run-test "echo Completed"
+PIPE_FILE="$(mktemp)"
+test_function ${SUCCESS} "$PIPE_FILE" main --run-test "rm -f $PIPE_FILE" --run-test "touch $PIPE_FILE" --run-test "ls $PIPE_FILE"
+
 echo ">> All tests passed"

--- a/tools/config-generator/templates/prow_config.yaml
+++ b/tools/config-generator/templates/prow_config.yaml
@@ -42,6 +42,8 @@ deck:
           - 'panic: test timed out after.*$'
           # test case failure
           - 'FAIL:'
+          # step failed
+          - 'Step failed:'
           # boskos error
           - 'boskos failed to acquire project'
           # cluster creation error


### PR DESCRIPTION
* Restore presubmit run multiple scripts functionality (#1811)

A revert [1] was performed due to test failures on test execution. The root cause was related to the line of code:
```bash
for test_to_run in ${TESTS_TO_RUN[@]}; do
```

TESTS_TO_RUN is a list of strings which can contain internally different separated words (command --arguments). By iterating this way, we are splitting every single string on the whole list and therefore considering every single word a valid command, which triggered the failures. Log statement:
```
./test/../vendor/knative.dev/test-infra/scripts/presubmit-tests.sh: line 373: --contour-version: command not found
Step failed: --contour-version
./test/../vendor/knative.dev/test-infra/scripts/presubmit-tests.sh: line 373: latest: command not found
Step failed: latest
+ EXIT_VALUE=1
+ set +o xtrace
```

We are restoring the original code change and applying the following iteration:
```bash
for test_to_run in "${TESTS_TO_RUN[@]}"; do
```

This has been proved to split the string list as we desire after manual validation. Further testing will be implemented.

[1] https://github.com/knative/test-infra/pull/1790/files

* Include unit tests for presubmit-tests

This will cover custom test execution and multi-script requests

* Include unit tests for presubmit-tests

This will cover custom test execution and multi-script requests

* Change static pipe file to dynamic allocated name per PR feedback

Co-authored-by: Alberto Milan Gutierrez <albertomilan@google.com>

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

